### PR TITLE
Add Goa generator that generate Get func for HTTP Headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,7 @@ deps: $(VENDOR_DIR)
 app/controllers.go: $(DESIGNS) $(GOAGEN_BIN) $(VENDOR_DIR)
 	$(GOAGEN_BIN) app -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) controller -d ${PACKAGE_NAME}/${DESIGN_DIR} -o controller/ --pkg controller --app-pkg app
+	$(GOAGEN_BIN) gen -d ${PACKAGE_NAME}/${DESIGN_DIR} --pkg-path=${PACKAGE_NAME}/goa_header_methods --out app
 	$(GOAGEN_BIN) client -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) swagger -d ${PACKAGE_NAME}/${DESIGN_DIR}
 

--- a/goa_header_methods/generator.go
+++ b/goa_header_methods/generator.go
@@ -1,0 +1,107 @@
+package goaheadermethods
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/goagen/codegen"
+)
+
+// Generate adds Get`Header`() methods to the XContext objects
+func Generate() ([]string, error) {
+	var (
+		ver    string
+		outDir string
+	)
+	set := flag.NewFlagSet("app", flag.PanicOnError)
+	set.String("design", "", "") // Consume design argument so Parse doesn't complain
+	set.StringVar(&ver, "version", "", "")
+	set.StringVar(&outDir, "out", "", "")
+	set.Parse(os.Args[2:])
+
+	// First check compatibility
+	if err := codegen.CheckVersion(ver); err != nil {
+		return nil, err
+	}
+
+	return WriteNames(design.Design, outDir)
+}
+
+// RequestContext holds a single goa Request Context object
+type RequestContext struct {
+	Name    string
+	Headers []RequestHeader
+}
+
+// RequestHeader holds a single HTTP Header as defined in the design for a Request Context
+type RequestHeader struct {
+	Name   string
+	Header string
+	Type   string
+}
+
+// WriteNames creates the names.txt file.
+func WriteNames(api *design.APIDefinition, outDir string) ([]string, error) {
+	// Now iterate through the resources to gather their names
+	var rcs []RequestContext
+	api.IterateResources(func(res *design.ResourceDefinition) error {
+		res.IterateActions(func(act *design.ActionDefinition) error {
+			if act.Headers != nil {
+
+				name := fmt.Sprintf("%v%vContext", codegen.Goify(act.Name, true), codegen.Goify(res.Name, true))
+				rc := RequestContext{Name: name}
+				for header, value := range act.Headers.Type.ToObject() {
+					rc.Headers = append(
+						rc.Headers,
+						RequestHeader{
+							Name:   codegen.Goify(header, true),
+							Header: header,
+							Type:   codegen.GoTypeRef(value.Type, nil, 0, false),
+						})
+				}
+				rcs = append(rcs, rc)
+			}
+			return nil
+		})
+		return nil
+	})
+
+	ctxFile := filepath.Join(outDir, "context_headers.go")
+	ctxWr, err := codegen.SourceFileFor(ctxFile)
+	if err != nil {
+		panic(err) // bug
+	}
+	title := fmt.Sprintf("%s: Contex Header Methods", api.Context())
+	imports := []*codegen.ImportSpec{
+		codegen.SimpleImport("fmt"),
+		codegen.SimpleImport("net/http"),
+		codegen.SimpleImport("strconv"),
+		codegen.SimpleImport("strings"),
+		codegen.SimpleImport("time"),
+		codegen.SimpleImport("unicode/utf8"),
+	}
+
+	ctxWr.WriteHeader(title, "app", imports)
+	if err := ctxWr.ExecuteTemplate("headerMethods", headerMethods, nil, rcs); err != nil {
+		return nil, err
+	}
+	err = ctxWr.FormatCode()
+	if err != nil {
+		return nil, err
+	}
+	return []string{ctxFile}, nil
+}
+
+const (
+	headerMethods = `
+{{ range $req := . }}{{ range $head := $req.Headers }}
+// Get{{ $head.Name }} return the HTTP Header {{ $head.Header }}
+func (ctx *{{$req.Name}}) Get{{ $head.Name }}() *{{ $head.Type }} {
+	return ctx.{{ $head.Name }}
+}{{ end }}
+{{ end }}
+`
+)


### PR DESCRIPTION
Generates the following based on the the current Design

```go
// Code generated by goagen v1.1.0, command line:
// $ goagen
// --design=github.com/almighty/almighty-core/design
// --out=$(GOPATH)/src/github.com/almighty/almighty-core/app
// --version=v1.1.0
//
// API "alm": Contex Header Methods
//
// The content of this file is auto-generated, DO NOT MODIFY

package app

import "time"

// GetIfModifiedSince return the HTTP Header If-Modified-Since
func (ctx *ListWorkitemtypeContext) GetIfModifiedSince() *time.Time {
	return ctx.IfModifiedSince
}

// GetIfNoneMatch return the HTTP Header If-None-Match
func (ctx *ListWorkitemtypeContext) GetIfNoneMatch() *string {
	return ctx.IfNoneMatch
}

// GetIfModifiedSince return the HTTP Header If-Modified-Since
func (ctx *ListSourceLinkTypesWorkitemtypeContext) GetIfModifiedSince() *time.Time {
	return ctx.IfModifiedSince
}

// GetIfNoneMatch return the HTTP Header If-None-Match
func (ctx *ListSourceLinkTypesWorkitemtypeContext) GetIfNoneMatch() *string {
	return ctx.IfNoneMatch
}

// GetIfNoneMatch return the HTTP Header If-None-Match
func (ctx *ListTargetLinkTypesWorkitemtypeContext) GetIfNoneMatch() *string {
	return ctx.IfNoneMatch
}

// GetIfModifiedSince return the HTTP Header If-Modified-Since
func (ctx *ListTargetLinkTypesWorkitemtypeContext) GetIfModifiedSince() *time.Time {
	return ctx.IfModifiedSince
}

// GetIfModifiedSince return the HTTP Header If-Modified-Since
func (ctx *ShowWorkitemtypeContext) GetIfModifiedSince() *time.Time {
	return ctx.IfModifiedSince
}

// GetIfNoneMatch return the HTTP Header If-None-Match
func (ctx *ShowWorkitemtypeContext) GetIfNoneMatch() *string {
	return ctx.IfNoneMatch
}
```

You can now create an interface that all the context ahere to:

```go
type ConditionalRequest interface {
    GetIfNoneMatch() *string
    GetIfModifiedSince() *time.Time
}

func conditional(cr ConditionalRequest) { ... }

return conditional(ctx)
```

Maybe even add the ctx.NotModifed() method there. That way our functions are enforcing the design to be coherent. 

wdyt?